### PR TITLE
[Feature] 어드민 페이지 event list api 구현

### DIFF
--- a/src/main/java/com/softeer/podo/admin/controller/AdminController.java
+++ b/src/main/java/com/softeer/podo/admin/controller/AdminController.java
@@ -1,0 +1,27 @@
+package com.softeer.podo.admin.controller;
+
+import com.softeer.podo.admin.model.dto.EventListResponseDto;
+import com.softeer.podo.admin.service.AdminService;
+import com.softeer.podo.common.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+@Slf4j
+public class AdminController {
+	private final AdminService adminService;
+
+
+	@GetMapping("/eventlist")
+	@Operation(summary = "이벤트 목록 반환 Api")
+	public CommonResponse<EventListResponseDto> eventList(){
+		return new CommonResponse<>(adminService.getEventList());
+	}
+
+}

--- a/src/main/java/com/softeer/podo/admin/model/dto/EventDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/EventDto.java
@@ -1,0 +1,31 @@
+package com.softeer.podo.admin.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class EventDto{
+	private Long id;
+	private String eventType;
+	private String title;
+	private String description;
+	/**
+	 * 형식은 7자리 0과 1로 이루어진 문자열. 월화수목금토일 의미
+	 */
+	private String repeatDay;
+	@JsonFormat(pattern = "HH:mm:ss")
+	private LocalDateTime repeatTime;
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	private LocalDateTime startAt;
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	private LocalDateTime endAt;
+	private String tagImage;
+
+	private List<EventRewardDto> eventRewardList;
+	private EventWeightDto eventWeight;
+}

--- a/src/main/java/com/softeer/podo/admin/model/dto/EventDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/EventDto.java
@@ -1,6 +1,8 @@
 package com.softeer.podo.admin.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.annotation.Nullable;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,6 +11,7 @@ import java.util.List;
 
 @Data
 @Builder
+@JsonInclude(JsonInclude.Include.ALWAYS) // null 값 포함
 public class EventDto{
 	private Long id;
 	private String eventType;
@@ -17,8 +20,10 @@ public class EventDto{
 	/**
 	 * 형식은 7자리 0과 1로 이루어진 문자열. 월화수목금토일 의미
 	 */
+	@Nullable
 	private String repeatDay;
 	@JsonFormat(pattern = "HH:mm:ss")
+	@Nullable
 	private LocalDateTime repeatTime;
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private LocalDateTime startAt;
@@ -27,5 +32,6 @@ public class EventDto{
 	private String tagImage;
 
 	private List<EventRewardDto> eventRewardList;
+	@Nullable
 	private EventWeightDto eventWeight;
 }

--- a/src/main/java/com/softeer/podo/admin/model/dto/EventListResponseDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/EventListResponseDto.java
@@ -1,0 +1,12 @@
+package com.softeer.podo.admin.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class EventListResponseDto {
+	List<EventDto> eventList;
+}

--- a/src/main/java/com/softeer/podo/admin/model/dto/EventRewardDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/EventRewardDto.java
@@ -1,0 +1,12 @@
+package com.softeer.podo.admin.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class EventRewardDto{
+	private int rank;
+	private int numWinners;
+	private String reward;
+}

--- a/src/main/java/com/softeer/podo/admin/model/dto/EventWeightDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/EventWeightDto.java
@@ -1,0 +1,11 @@
+package com.softeer.podo.admin.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class EventWeightDto{
+	private int times;
+	private String condition;
+}

--- a/src/main/java/com/softeer/podo/admin/model/dto/mapper/AdminMapper.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/mapper/AdminMapper.java
@@ -1,0 +1,57 @@
+package com.softeer.podo.admin.model.dto.mapper;
+
+import com.softeer.podo.admin.model.dto.EventDto;
+import com.softeer.podo.admin.model.dto.EventListResponseDto;
+import com.softeer.podo.admin.model.dto.EventRewardDto;
+import com.softeer.podo.admin.model.dto.EventWeightDto;
+import com.softeer.podo.admin.model.entity.Event;
+import com.softeer.podo.admin.model.entity.EventReward;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class AdminMapper {
+
+	public EventListResponseDto eventListToEventListResponseDto(List<Event> eventList){
+
+		List<EventDto> eventDtoList = new ArrayList<>();
+		for (Event event : eventList) {
+			List<EventRewardDto> eventRewardDtoList = new ArrayList<>();
+			for(EventReward eventReward : event.getEventRewardList()){
+				eventRewardDtoList.add(
+						new EventRewardDto(
+								eventReward.getRewardRank(),
+								eventReward.getNumWinners(),
+								eventReward.getReward()
+						)
+				);
+			}
+
+
+			eventDtoList.add(
+					EventDto.builder()
+							.id(event.getId())
+							.eventType(event.getEventType().getType())
+							.title(event.getTitle())
+							.description(event.getDescription())
+							.repeatDay(event.getRepeatDay())
+							.repeatTime(event.getRepeatTime())
+							.startAt(event.getStartAt())
+							.endAt(event.getEndAt())
+							.tagImage(event.getTagImage())
+							.eventRewardList(eventRewardDtoList)
+							.eventWeight(
+									new EventWeightDto(
+											event.getEventWeight().getTimes(),
+											event.getEventWeight().getWeightCondition()
+									)
+							)
+							.build()
+			);
+		}
+
+		return new EventListResponseDto(eventDtoList);
+	}
+}

--- a/src/main/java/com/softeer/podo/admin/model/dto/mapper/AdminMapper.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/mapper/AdminMapper.java
@@ -43,6 +43,8 @@ public class AdminMapper {
 							.tagImage(event.getTagImage())
 							.eventRewardList(eventRewardDtoList)
 							.eventWeight(
+									(event.getEventWeight() == null)?
+											null :
 									new EventWeightDto(
 											event.getEventWeight().getTimes(),
 											event.getEventWeight().getWeightCondition()

--- a/src/main/java/com/softeer/podo/admin/model/entity/Event.java
+++ b/src/main/java/com/softeer/podo/admin/model/entity/Event.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "events")
@@ -23,7 +24,7 @@ public class Event extends DateEntity {
     @Column(name = "event_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "type_id")
     private EventType eventType;
 
@@ -48,4 +49,10 @@ public class Event extends DateEntity {
 
     @Column(name = "tag_image")
     private String tagImage;
+
+    @OneToMany(mappedBy = "event" , orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<EventReward> eventRewardList;
+
+    @OneToOne(mappedBy = "event" , orphanRemoval = true, cascade = CascadeType.ALL)
+    private EventWeight eventWeight;
 }

--- a/src/main/java/com/softeer/podo/admin/model/entity/Event.java
+++ b/src/main/java/com/softeer/podo/admin/model/entity/Event.java
@@ -1,0 +1,51 @@
+package com.softeer.podo.admin.model.entity;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.softeer.podo.common.entity.DateEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "events")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Event extends DateEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "type_id")
+    private EventType eventType;
+
+    private String title;
+    private String description;
+
+    /**
+     * 형식은 7자리 0과 1로 이루어진 문자열. 월화수목금토일 의미
+     */
+    @Column(name = "repeat_day")
+    private String repeatDay;
+    @JsonFormat(pattern = "HH:mm:ss")
+    @Column(name = "repeat_time")
+    private LocalDateTime repeatTime;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Column(name = "start_time")
+    private LocalDateTime startAt;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Column(name = "end_time")
+    private LocalDateTime endAt;
+
+    @Column(name = "tag_image")
+    private String tagImage;
+}

--- a/src/main/java/com/softeer/podo/admin/model/entity/Event.java
+++ b/src/main/java/com/softeer/podo/admin/model/entity/Event.java
@@ -24,7 +24,7 @@ public class Event extends DateEntity {
     @Column(name = "event_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "type_id")
     private EventType eventType;
 

--- a/src/main/java/com/softeer/podo/admin/model/entity/EventReward.java
+++ b/src/main/java/com/softeer/podo/admin/model/entity/EventReward.java
@@ -28,7 +28,7 @@ public class EventReward extends DateEntity {
     private int numWinners;
     private String reward;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
     private Event event;
 }

--- a/src/main/java/com/softeer/podo/admin/model/entity/EventReward.java
+++ b/src/main/java/com/softeer/podo/admin/model/entity/EventReward.java
@@ -1,0 +1,34 @@
+package com.softeer.podo.admin.model.entity;
+
+import com.softeer.podo.common.entity.DateEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Table(name = "event_rewards")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventReward extends DateEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reward_id")
+    private Long id;
+    @Column(name = "reward_rank")
+    private int rewardRank;
+    /**
+     * 당첨자수
+     */
+    @Column(name = "winner_number")
+    private int numWinners;
+    private String reward;
+
+    @ManyToOne
+    @JoinColumn(name = "event_id")
+    private Event event;
+}

--- a/src/main/java/com/softeer/podo/admin/model/entity/EventType.java
+++ b/src/main/java/com/softeer/podo/admin/model/entity/EventType.java
@@ -1,0 +1,24 @@
+package com.softeer.podo.admin.model.entity;
+
+
+import com.softeer.podo.common.entity.DateEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "event_types")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventType extends DateEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "type_id")
+    private Long id;
+    @Column(name = "type")
+    private String type;
+}

--- a/src/main/java/com/softeer/podo/admin/model/entity/EventWeight.java
+++ b/src/main/java/com/softeer/podo/admin/model/entity/EventWeight.java
@@ -1,0 +1,31 @@
+package com.softeer.podo.admin.model.entity;
+
+import com.softeer.podo.common.entity.DateEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "event_weights")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventWeight extends DateEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "weight_id")
+    private Long id;
+    /**
+     * 가중치 배수
+     */
+    private int times;
+    @Column(name = "weight_condition")
+    private String weightCondition;
+
+    @OneToOne
+    @JoinColumn(name =  "event_id")
+    private Event event;
+}

--- a/src/main/java/com/softeer/podo/admin/model/entity/EventWeight.java
+++ b/src/main/java/com/softeer/podo/admin/model/entity/EventWeight.java
@@ -25,7 +25,7 @@ public class EventWeight extends DateEntity {
     @Column(name = "weight_condition")
     private String weightCondition;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name =  "event_id")
     private Event event;
 }

--- a/src/main/java/com/softeer/podo/admin/repository/EventRepository.java
+++ b/src/main/java/com/softeer/podo/admin/repository/EventRepository.java
@@ -1,0 +1,7 @@
+package com.softeer.podo.admin.repository;
+
+import com.softeer.podo.admin.model.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/softeer/podo/admin/repository/EventRewardRepository.java
+++ b/src/main/java/com/softeer/podo/admin/repository/EventRewardRepository.java
@@ -1,0 +1,7 @@
+package com.softeer.podo.admin.repository;
+
+import com.softeer.podo.admin.model.entity.EventReward;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRewardRepository extends JpaRepository<EventReward, Long> {
+}

--- a/src/main/java/com/softeer/podo/admin/repository/EventTypeRepository.java
+++ b/src/main/java/com/softeer/podo/admin/repository/EventTypeRepository.java
@@ -1,0 +1,7 @@
+package com.softeer.podo.admin.repository;
+
+import com.softeer.podo.admin.model.entity.EventType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventTypeRepository extends JpaRepository<EventType, Long> {
+}

--- a/src/main/java/com/softeer/podo/admin/repository/EventWeightRepository.java
+++ b/src/main/java/com/softeer/podo/admin/repository/EventWeightRepository.java
@@ -1,0 +1,7 @@
+package com.softeer.podo.admin.repository;
+
+import com.softeer.podo.admin.model.entity.EventWeight;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventWeightRepository extends JpaRepository<EventWeight, Long> {
+}

--- a/src/main/java/com/softeer/podo/admin/service/AdminService.java
+++ b/src/main/java/com/softeer/podo/admin/service/AdminService.java
@@ -1,0 +1,24 @@
+package com.softeer.podo.admin.service;
+
+
+import com.softeer.podo.admin.model.dto.EventListResponseDto;
+import com.softeer.podo.admin.model.dto.mapper.AdminMapper;
+import com.softeer.podo.admin.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+	private final EventRepository eventRepository;
+
+	private final AdminMapper adminMapper;
+
+	@Transactional
+	public EventListResponseDto getEventList() {
+		return adminMapper.eventListToEventListResponseDto(eventRepository.findAll());
+	}
+
+
+}

--- a/src/main/java/com/softeer/podo/config/FilterConfig.java
+++ b/src/main/java/com/softeer/podo/config/FilterConfig.java
@@ -21,7 +21,7 @@ public class FilterConfig {
         FilterRegistrationBean<JwtAuthenticationFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new JwtAuthenticationFilter(tokenProvider));
         registrationBean.addUrlPatterns("/test/auth"); // 필터를 적용할 URL 패턴
-        registrationBean.addUrlPatterns("/v1/lots/*"); // 필터를 적용할 URL 패턴
+        registrationBean.addUrlPatterns("/v1/*"); // 필터를 적용할 URL 패턴
         registrationBean.setOrder(2); // 필터의 순서 (숫자가 낮을수록 먼저 실행됨)
         return registrationBean;
     }

--- a/src/main/java/com/softeer/podo/verification/controller/VerificationController.java
+++ b/src/main/java/com/softeer/podo/verification/controller/VerificationController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 
 @RestController
-@RequestMapping("/v1/verification")
+@RequestMapping("/verification")
 @RequiredArgsConstructor
 public class VerificationController {
 

--- a/src/test/java/com/softeer/podo/common/EventInsertionTest.java
+++ b/src/test/java/com/softeer/podo/common/EventInsertionTest.java
@@ -1,0 +1,121 @@
+package com.softeer.podo.common;
+
+
+import com.softeer.podo.admin.model.entity.Event;
+import com.softeer.podo.admin.model.entity.EventReward;
+import com.softeer.podo.admin.model.entity.EventType;
+import com.softeer.podo.admin.model.entity.EventWeight;
+import com.softeer.podo.admin.repository.EventRepository;
+import com.softeer.podo.admin.repository.EventRewardRepository;
+import com.softeer.podo.admin.repository.EventWeightRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
+@SpringBootTest
+public class EventInsertionTest {
+	@Autowired
+	private EventRepository eventRepository;
+	@Autowired
+	private EventWeightRepository eventWeightRepository;
+	@Autowired
+	private EventRewardRepository eventRewardRepository;
+
+	@Test
+	@DisplayName("선착순 Event정보 입력용 테스트")
+	public void insertArrivalEventTest() {
+		Event event = eventRepository.save(
+				Event.builder()
+						.eventType(EventType.builder().type("arrival").build())
+						.title("셀토스 선착순 이벤트")
+						.description("The 2025 셀토스 출시 기념 선착순 이벤트")
+						.repeatDay("1111100")
+						.repeatTime(LocalDateTime.of(2024, 9, 6, 15, 0, 0))
+						.startAt(LocalDateTime.of(2024, 9, 6, 0, 0, 0))
+						.endAt(LocalDateTime.of(2024, 9, 9, 18, 0, 0))
+						.tagImage("image url")
+						.build()
+		);
+
+		List<EventReward> eventRewards = new ArrayList<>();
+		eventRewards.add(
+				EventReward.builder()
+						.numWinners(100)
+						.rewardRank(1)
+						.reward("스타벅스 커피 쿠폰")
+						.event(event)
+						.build()
+		);
+
+		eventRewardRepository.saveAll(eventRewards);
+
+
+		assertNotNull(event);
+	}
+
+
+
+	@Test
+	@DisplayName("랜덤추첨 Event정보 입력용 테스트")
+	public void insertLotsEventTest() {
+		Event event = eventRepository.save(
+				Event.builder()
+						.eventType(EventType.builder().type("lots").build())
+						.title("셀토스 추첨 이벤트")
+						.description("The 2025 셀토스 출시 기념 추첨 이벤트")
+						.startAt(LocalDateTime.of(2024, 9, 6, 0, 0, 0))
+						.endAt(LocalDateTime.of(2024, 9, 9, 18, 0, 0))
+						.tagImage("image url")
+						.build()
+		);
+
+		List<EventReward> eventRewards = new ArrayList<>();
+		eventRewards.add(
+				EventReward.builder()
+						.numWinners(1)
+						.rewardRank(1)
+						.reward("시그니엘 숙박권")
+						.event(event)
+						.build()
+		);
+		eventRewards.add(
+				EventReward.builder()
+						.numWinners(3)
+						.rewardRank(2)
+						.reward("파인다이닝 식사권")
+						.event(event)
+						.build()
+		);
+		eventRewards.add(
+				EventReward.builder()
+						.numWinners(10)
+						.rewardRank(3)
+						.reward("현대백화점 상품권")
+						.event(event)
+						.build()
+		);
+
+		eventRewardRepository.saveAll(eventRewards);
+
+		eventWeightRepository.save(
+				EventWeight.builder()
+						.times(3)
+						.weightCondition("기대평")
+						.event(event)
+						.build()
+		);
+
+
+		assertNotNull(event);
+	}
+
+}


### PR DESCRIPTION
## 🎯 이슈 번호

#21 [Feature] 어드민 페이지용 api 구현

## 💡 작업 내용

- [x] 이벤트 목록 api 구현

## 💡 자세한 설명

Event 목록들에 대해 가중치와 상품들을 모두 종합하여 양식대로 이벤트 목록을 json 형식으로 반환 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?
