### PR TITLE
[Feat] admin 페이지 응모자 목록 페이징 및 이벤트 수정 response 내용 추가

### DIFF
--- a/src/main/java/com/softeer/podo/admin/controller/AdminController.java
+++ b/src/main/java/com/softeer/podo/admin/controller/AdminController.java
@@ -54,14 +54,14 @@ public class AdminController {
 
 	@GetMapping("/arrival/applicationList")
 	@Operation(summary = "선착순 응모 인원 반환 Api")
-	public CommonResponse<ArrivalUserListDto> arrivalApplicationList(){
-		return new CommonResponse<>(adminService.getArrivalApplicationList());
+	public CommonResponse<ArrivalUserListDto> arrivalApplicationList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo){
+		return new CommonResponse<>(adminService.getArrivalApplicationList(pageNo));
 	}
 
 	@GetMapping("/lots/applicationList")
 	@Operation(summary = "랜덤추첨 응모 인원 반환 Api")
-	public CommonResponse<LotsUserListDto> lotsApplicationList(){
-		return new CommonResponse<>(adminService.getLotsApplicationList());
+	public CommonResponse<LotsUserListDto> lotsApplicationList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo){
+		return new CommonResponse<>(adminService.getLotsApplicationList(pageNo));
 	}
 
 	@GetMapping("/lots/pickrandom")

--- a/src/main/java/com/softeer/podo/admin/controller/AdminController.java
+++ b/src/main/java/com/softeer/podo/admin/controller/AdminController.java
@@ -42,13 +42,13 @@ public class AdminController {
 
 	@PutMapping("/arrival/rewardconfig")
 	@Operation(summary = "선착순 이벤트 상품 수정 Api")
-	public CommonResponse<ArrivalUserListDto> arrivalEventRewardConfig(@RequestBody @Valid EventRewardConfigRequestDto dto){
+	public CommonResponse<EventRewardConfigResponseDto> arrivalEventRewardConfig(@RequestBody @Valid EventRewardConfigRequestDto dto){
 		return new CommonResponse<>(adminService.configArrivalEventReward(dto));
 	}
 
 	@PutMapping("/lots/rewardconfig")
 	@Operation(summary = "랜덤추첨 이벤트 상품 수정 Api")
-	public CommonResponse<LotsUserListDto> lotsEventRewardConfig(@RequestBody @Validated(LotsValidationSequence.class) EventRewardConfigRequestDto dto){
+	public CommonResponse<EventRewardConfigResponseDto> lotsEventRewardConfig(@RequestBody @Validated(LotsValidationSequence.class) EventRewardConfigRequestDto dto){
 		return new CommonResponse<>(adminService.configLotsEventReward(dto));
 	}
 

--- a/src/main/java/com/softeer/podo/admin/model/dto/EventRewardConfigResponseDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/EventRewardConfigResponseDto.java
@@ -1,0 +1,17 @@
+package com.softeer.podo.admin.model.dto;
+
+import com.softeer.podo.admin.model.dto.user.UserListDto;
+import jakarta.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class EventRewardConfigResponseDto {
+	private List<EventRewardDto> eventRewards;
+	@Nullable
+	private EventWeightDto eventWeight;
+	private UserListDto userListPage;
+}

--- a/src/main/java/com/softeer/podo/admin/model/dto/mapper/EventMapper.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/mapper/EventMapper.java
@@ -6,6 +6,7 @@ import com.softeer.podo.admin.model.dto.EventRewardDto;
 import com.softeer.podo.admin.model.dto.EventWeightDto;
 import com.softeer.podo.admin.model.entity.Event;
 import com.softeer.podo.admin.model.entity.EventReward;
+import com.softeer.podo.admin.model.entity.EventWeight;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -49,5 +50,11 @@ public class EventMapper {
 		return new EventListResponseDto(eventDtoList);
 	}
 
+	public static EventRewardDto eventRewardToEventRewardDto(EventReward eventReward){
+		return new EventRewardDto(eventReward.getRewardRank(), eventReward.getNumWinners(), eventReward.getReward());
+	}
 
+	public static EventWeightDto eventWeightToEventWeightDto(EventWeight eventWeight){
+		return new EventWeightDto(eventWeight.getTimes(), eventWeight.getWeightCondition());
+	}
 }

--- a/src/main/java/com/softeer/podo/admin/model/dto/mapper/UserMapper.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/mapper/UserMapper.java
@@ -7,16 +7,16 @@ import com.softeer.podo.admin.model.dto.user.LotsUserDto;
 import com.softeer.podo.admin.model.dto.user.LotsUserListDto;
 import com.softeer.podo.admin.model.entity.ArrivalUser;
 import com.softeer.podo.admin.model.entity.LotsUser;
-import org.springframework.stereotype.Component;
+import org.springframework.data.domain.Page;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class UserMapper {
 
-	public static ArrivalUserListDto ArrivalUserListToArrivalUserListDto(List<ArrivalUser> userList) {
+	public static ArrivalUserListDto ArrivalUserPageToArrivalUserListDto(Page<ArrivalUser> userPage) {
 		List<ArrivalUserDto> arrivalUserDtoList = new ArrayList<>();
-		for(ArrivalUser user : userList) {
+		for(ArrivalUser user : userPage.getContent()) {
 			//reward를 제외한 내용 추가
 			arrivalUserDtoList.add(
 					ArrivalUserDto.builder()
@@ -28,12 +28,12 @@ public class UserMapper {
 							.build()
 			);
 		}
-		return new ArrivalUserListDto(arrivalUserDtoList);
+		return new ArrivalUserListDto(userPage.getTotalPages(), userPage.getNumber(), arrivalUserDtoList);
 	}
 
-	public static LotsUserListDto LotsUserListToLotsUserListDto(List<LotsUser> userList) {
+	public static LotsUserListDto LotsUserPageToLotsUserListDto(Page<LotsUser> userPage) {
 		List<LotsUserDto> lotsUserDtoList = new ArrayList<>();
-		for(LotsUser user : userList) {
+		for(LotsUser user : userPage.getContent()) {
 			//reward를 제외한 내용 추가
 			lotsUserDtoList.add(
 					LotsUserDto.builder()
@@ -45,6 +45,6 @@ public class UserMapper {
 							.build()
 			);
 		}
-		return new LotsUserListDto(lotsUserDtoList);
+		return new LotsUserListDto(userPage.getTotalPages(), userPage.getNumber(), lotsUserDtoList);
 	}
 }

--- a/src/main/java/com/softeer/podo/admin/model/dto/user/ArrivalUserListDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/user/ArrivalUserListDto.java
@@ -8,5 +8,7 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 public class ArrivalUserListDto {
+	int totalPage;
+	int currentPage;
 	List<ArrivalUserDto> arrivalUserList;
 }

--- a/src/main/java/com/softeer/podo/admin/model/dto/user/ArrivalUserListDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/user/ArrivalUserListDto.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Data
 @AllArgsConstructor
-public class ArrivalUserListDto {
+public class ArrivalUserListDto implements UserListDto {
 	int totalPage;
 	int currentPage;
 	List<ArrivalUserDto> arrivalUserList;

--- a/src/main/java/com/softeer/podo/admin/model/dto/user/LotsUserListDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/user/LotsUserListDto.java
@@ -8,5 +8,7 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 public class LotsUserListDto {
+	int totalPage;
+	int currentPage;
 	List<LotsUserDto> lotsUserList;
 }

--- a/src/main/java/com/softeer/podo/admin/model/dto/user/LotsUserListDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/user/LotsUserListDto.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Data
 @AllArgsConstructor
-public class LotsUserListDto {
+public class LotsUserListDto implements UserListDto {
 	int totalPage;
 	int currentPage;
 	List<LotsUserDto> lotsUserList;

--- a/src/main/java/com/softeer/podo/admin/model/dto/user/UserListDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/user/UserListDto.java
@@ -1,0 +1,4 @@
+package com.softeer.podo.admin.model.dto.user;
+
+public interface UserListDto {
+}

--- a/src/main/java/com/softeer/podo/admin/service/AdminService.java
+++ b/src/main/java/com/softeer/podo/admin/service/AdminService.java
@@ -7,6 +7,7 @@ import com.softeer.podo.admin.model.dto.user.ArrivalUserListDto;
 import com.softeer.podo.admin.model.dto.mapper.EventMapper;
 import com.softeer.podo.admin.model.dto.mapper.UserMapper;
 import com.softeer.podo.admin.model.dto.user.LotsUserListDto;
+import com.softeer.podo.admin.model.entity.ArrivalUser;
 import com.softeer.podo.admin.model.entity.Event;
 import com.softeer.podo.admin.model.entity.EventReward;
 import com.softeer.podo.admin.model.exception.EventNotFoundException;
@@ -16,6 +17,10 @@ import com.softeer.podo.admin.repository.ArrivalUserRepository;
 import com.softeer.podo.admin.repository.EventRewardRepository;
 import com.softeer.podo.admin.repository.LotsUserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +36,7 @@ public class AdminService {
 
 	private final Long arrivalEventId = 1L;
 	private final Long lotsEventId = 2L;
+	private final int PAGE_SIZE = 10;
 
 	@Transactional
 	public EventListResponseDto getEventList() {
@@ -66,7 +72,7 @@ public class AdminService {
 		}
 		eventRewardRepository.flush(); // 즉시 데이터베이스에 반영
 
-		return getArrivalApplicationList();
+		return getArrivalApplicationList(0);
 	}
 
 	@Transactional
@@ -88,12 +94,14 @@ public class AdminService {
 		lotsEvent.getEventWeight().updateTimes(dto.getEventWeight().getTimes());
 		eventRewardRepository.flush(); // 즉시 데이터베이스에 반영
 
-		return getLotsApplicationList();
+		return getLotsApplicationList(0);
 	}
 
 	@Transactional
-	public ArrivalUserListDto getArrivalApplicationList() {
-		ArrivalUserListDto arrivalUserListDto = UserMapper.ArrivalUserListToArrivalUserListDto(arrivalUserRepository.findAll());
+	public ArrivalUserListDto getArrivalApplicationList(int pageNo) {
+		Pageable pageable = PageRequest.of(pageNo, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "id"));
+		Page<ArrivalUser> page = arrivalUserRepository.findAll(pageable);
+		ArrivalUserListDto arrivalUserListDto = UserMapper.ArrivalUserPageToArrivalUserListDto(page);
 		//선착순 이벤트 id
 		Event arrivalEvent = eventRepository.findById(arrivalEventId).orElseThrow(EventNotFoundException::new);
 		List<EventReward> eventRewardList = arrivalEvent.getEventRewardList();
@@ -115,8 +123,10 @@ public class AdminService {
 	}
 
 	@Transactional
-	public LotsUserListDto getLotsApplicationList() {
-		return UserMapper.LotsUserListToLotsUserListDto(lotsUserRepository.findAll());
+	public LotsUserListDto getLotsApplicationList(int pageNo) {
+		Pageable pageable = PageRequest.of(pageNo, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "id"));
+		Page<LotsUser> page = lotsUserRepository.findAll(pageable);
+		return UserMapper.LotsUserPageToLotsUserListDto(page);
 	}
 
 	@Transactional
@@ -174,7 +184,7 @@ public class AdminService {
 			lotsUserRepository.save(lotsUserList.get(i));
 		}
 
-		return getLotsApplicationList();
+		return getLotsApplicationList(0);
 	}
 
 	private Event updateEventByConfigDto(Long eventId, EventConfigRequestDto dto) {

--- a/src/test/java/com/softeer/podo/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/softeer/podo/admin/controller/AdminControllerTest.java
@@ -158,7 +158,7 @@ class AdminControllerTest {
 		assertEquals(true, response.get("isSuccess"));
 		assertEquals(200, response.get("code"));
 
-		JSONArray applicationArray = response.getJSONObject("result").getJSONArray("arrivalUserList");
+		JSONArray applicationArray = response.getJSONObject("result").getJSONObject("userListPage").getJSONArray("arrivalUserList");
 		for(int i = 0; i < applicationArray.length(); i++){  //보상 확인
 			JSONObject user = applicationArray.getJSONObject(i);
 			int rank = user.getInt("rank");

--- a/src/test/java/com/softeer/podo/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/softeer/podo/admin/service/AdminServiceTest.java
@@ -257,7 +257,8 @@ class AdminServiceTest {
 		EventRewardConfigResponseDto responseDto = adminService.configArrivalEventReward(requestDto);
 
 		//then
-		assertEquals(rewardNum, arrivalEvent.getEventRewardList().size());
+		assertEquals(eventRewardList, responseDto.getEventRewards());
+
 		ArrivalUserListDto arrivalUserListPageDto = (ArrivalUserListDto) responseDto.getUserListPage();
 		for(int i = 0; i < arrivalUserListPageDto.getArrivalUserList().size(); i++){  //보상 확인
 			ArrivalUserDto user = arrivalUserListPageDto.getArrivalUserList().get(i);
@@ -305,14 +306,17 @@ class AdminServiceTest {
 		}
 		EventRewardConfigRequestDto requestDto = new EventRewardConfigRequestDto();
 		requestDto.setEventRewardList(eventRewardList);
-		requestDto.setEventWeight(new EventWeightDto(3, "comment"));
+
+		EventWeightDto eventWeight = new EventWeightDto(3, "comment");
+		requestDto.setEventWeight(eventWeight);
 
 
 		//when
 		EventRewardConfigResponseDto responseDto = adminService.configLotsEventReward(requestDto);
 
 		//then
-		assertEquals(rewardNum, lotsEvent.getEventRewardList().size());
+		assertEquals(eventRewardList, responseDto.getEventRewards());
+		assertEquals(eventWeight, responseDto.getEventWeight());
 	}
 
 	@Test


### PR DESCRIPTION
## 🎯 이슈 번호

## 💡 작업 내용

- [x] 응모자 목록 페이징
- [x] 이벤트 수정 response 변경

## 💡 자세한 설명

user list 반환시 페이징을 진행하여 반환
event 내용 수정 시 수정한 내용이 response에 추가되도록 수정
- EventRewardConfigResponseDto를 추가하여 적용


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
