### PR TITLE
[Fix] 랜덤추첨 상품 수정 로직 추가, 에러 response 통일 및 랜덤 추첨 사용자 반환시 comment 추가

### DIFF
--- a/src/main/java/com/softeer/podo/admin/exception/AdminExceptionHandler.java
+++ b/src/main/java/com/softeer/podo/admin/exception/AdminExceptionHandler.java
@@ -17,7 +17,7 @@ public class AdminExceptionHandler {
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	public CommonResponse<?> eventNotFoundException(EventNotFoundException e, HttpServletRequest request) {
 		log.warn("ADMIN-001> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-		return new CommonResponse<>(ErrorCode.EVENT_NOT_FOUND_ERROR);
+		return new CommonResponse<>(ErrorCode.EVENT_NOT_FOUND_ERROR, e.getMessage());
 	}
 
 }

--- a/src/main/java/com/softeer/podo/admin/model/dto/LotsUserDto.java
+++ b/src/main/java/com/softeer/podo/admin/model/dto/LotsUserDto.java
@@ -14,4 +14,5 @@ public class LotsUserDto {
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private LocalDateTime createdAt;
 	private String reward;
+	private String comment;
 }

--- a/src/main/java/com/softeer/podo/admin/model/mapper/UserMapper.java
+++ b/src/main/java/com/softeer/podo/admin/model/mapper/UserMapper.java
@@ -42,6 +42,7 @@ public class UserMapper {
 							.phoneNum(user.getPhoneNum())
 							.createdAt(user.getCreatedAt())
 							.reward(user.getReward())
+							.comment((user.getLotsComment() == null) ? null : user.getLotsComment().getComment())
 							.build()
 			);
 		}

--- a/src/main/java/com/softeer/podo/admin/service/AdminService.java
+++ b/src/main/java/com/softeer/podo/admin/service/AdminService.java
@@ -113,6 +113,8 @@ public class AdminService {
 						.toList();
 		EventWeightDto eventWeightDto = EventMapper.eventWeightToEventWeightDto(lotsEvent.getEventWeight());
 
+		getLotsResult();
+
 		return new ConfigEventRewardResponseDto(eventRewardDtoList, eventWeightDto, getLotsApplicationList(0, null, null));
 	}
 

--- a/src/main/java/com/softeer/podo/event/exception/EventExceptionHandler.java
+++ b/src/main/java/com/softeer/podo/event/exception/EventExceptionHandler.java
@@ -18,48 +18,48 @@ public class EventExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public CommonResponse<?> existingPhoneNumbException(ExistingUserException e,  HttpServletRequest request) {
         log.warn("LOTS-001> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.PHONENUM_EXIST_ERROR);
+        return new CommonResponse<>(ErrorCode.PHONENUM_EXIST_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(InvalidSelectionException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public CommonResponse<?> invalidSelectionException(InvalidSelectionException e,  HttpServletRequest request) {
         log.warn("LOTS-002> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.INVALID_SELECTION_ERROR);
+        return new CommonResponse<>(ErrorCode.INVALID_SELECTION_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(UserNotExistException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public CommonResponse<?> userNotExistException(UserNotExistException e,  HttpServletRequest request) {
         log.warn("LOTS-003> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.USER_NOT_EXIST_ERROR);
+        return new CommonResponse<>(ErrorCode.USER_NOT_EXIST_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(ExistingCommentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public CommonResponse<?> existingCommentException(ExistingCommentException e,  HttpServletRequest request) {
         log.warn("LOTS-004> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.EXISTING_COMMENT_ERROR);
+        return new CommonResponse<>(ErrorCode.EXISTING_COMMENT_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(LotsShareLinkNotExistsException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public CommonResponse<?> lotsShareLinkNotExistsException(LotsShareLinkNotExistsException e,  HttpServletRequest request) {
         log.warn("LOTS-005> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.LOTS_LINK_NOT_EXISTS_ERROR);
+        return new CommonResponse<>(ErrorCode.LOTS_LINK_NOT_EXISTS_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(AESExecutionException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public CommonResponse<?> AESExecutionException(AESExecutionException e,  HttpServletRequest request) {
         log.warn("LOTS-006> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.AES_ENC_DEC_ERROR);
+        return new CommonResponse<>(ErrorCode.AES_ENC_DEC_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(InvalidResultTypeException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public CommonResponse<?> invalidResultTypeException(InvalidResultTypeException e,  HttpServletRequest request) {
         log.warn("LOTS-007> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.INVALID_RESULT_TYPE_ERROR);
+        return new CommonResponse<>(ErrorCode.INVALID_RESULT_TYPE_ERROR, e.getMessage());
     }
 }

--- a/src/main/java/com/softeer/podo/test/exception/TestExceptionHandler.java
+++ b/src/main/java/com/softeer/podo/test/exception/TestExceptionHandler.java
@@ -18,6 +18,6 @@ public class TestExceptionHandler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public CommonResponse<?> joseException(JOSEException e, HttpServletRequest request) {
         log.warn("TEST-001> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new CommonResponse<>(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
     }
 }

--- a/src/main/java/com/softeer/podo/verification/exception/VerificationExceptionHandler.java
+++ b/src/main/java/com/softeer/podo/verification/exception/VerificationExceptionHandler.java
@@ -17,20 +17,20 @@ public class VerificationExceptionHandler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public CommonResponse<?> messageSendFailException(MessageSendFailException e, HttpServletRequest request) {
         log.warn("VERIFICATION-001> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new CommonResponse<>(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(TokenNotMatchException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public CommonResponse<?> tokenNotMatchException(TokenNotMatchException e, HttpServletRequest request) {
         log.warn("VERIFICATION-002> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.INVALID_VERIFICATION_TOKEN_ERROR);
+        return new CommonResponse<>(ErrorCode.INVALID_VERIFICATION_TOKEN_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(DuplicatePhoneNumException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public CommonResponse<?> duplicatePhoneNumException(DuplicatePhoneNumException e, HttpServletRequest request) {
         log.warn("VERIFICATION-003> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
-        return new CommonResponse<>(ErrorCode.DUPLICATE_PHONENUM_ERROR);
+        return new CommonResponse<>(ErrorCode.DUPLICATE_PHONENUM_ERROR, e.getMessage());
     }
 }


### PR DESCRIPTION
## 🎯 이슈 번호

## 💡 작업 내용

- [x] error response가 항상 exception message를 출력하도록 수정
- [x] 랜덤추첨 상품 수정시 추첨 로직 추가 
- [x] lotsUserList 반환 시 comment 내용도 추가하여 반환

## 💡 자세한 설명
랜덤추첨 상품 수정 요청시, 해당 상품내용으로 추첨 진행
error response가 일부분은 exception message를 반환하지 않던 문제 해결
lots user list 반환시 comment 여부를 확인 못하던 문제 해결
## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?
