### PR TITLE
[Fix] 공유링크가 FE의 공유 결과 페이지에 직접 연결되도록 수정 및 공유링크 redirection api 기능 변경

### DIFF
--- a/src/main/java/com/softeer/podo/event/controller/EventLotsPageController.java
+++ b/src/main/java/com/softeer/podo/event/controller/EventLotsPageController.java
@@ -1,41 +1,36 @@
 package com.softeer.podo.event.controller;
 
+import com.softeer.podo.common.response.CommonResponse;
+import com.softeer.podo.common.response.ErrorCode;
 import com.softeer.podo.event.service.EventLotsService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/lots")
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class EventLotsPageController {
 
     private final EventLotsService eventLotsService;
 
     /**
-     * 고유 공유링크 클릭
-     * {uniqueLink}: 유저 id (암호화)
+     * 고유 공유링크 클릭시 FE에서 호출하는 api
+     * {UID}: 유저 id (암호화)
      */
-    @GetMapping("/link/{uniqueLink}")
-    @Operation(summary = "공유링크 클릭시 redirection하기 위함 (사용자 직접 호출용)")
-    public String shareLinkClick(
-            HttpServletResponse response,
-            @PathVariable String uniqueLink
-    ) {
+    @GetMapping("/link/{uid}")
+    @Operation(summary = "공유링크 클릭시 호출되는 api")
+    public CommonResponse<String> shareLinkClick(@PathVariable String uid) {
         try {
             // 해당 유저에 해당하는 적절한 이벤트 결과 페이지 찾기
-            String redirectUrl = eventLotsService.getEventUrl(uniqueLink);
+            String uniqueLink = eventLotsService.getEventUrl(uid);
             // 이벤트 결과 페이지 반환
-            return "redirect:" + redirectUrl;
+            return new CommonResponse<>(uniqueLink);
         } catch (Exception e) {
-            // 에러 페이지로 리다이렉션
-//            response.setStatus(HttpServletResponse.SC_FOUND);
-//            response.setHeader("Location", "/error/404");
-            return "/error/404";
+            // aes 복호화 exception
+            return new CommonResponse<>(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/softeer/podo/event/service/EventLotsService.java
+++ b/src/main/java/com/softeer/podo/event/service/EventLotsService.java
@@ -45,6 +45,7 @@ public class EventLotsService {
     private String SERVER_HOST;
     @Value("${server.port}")
     private String SERVER_PORT;
+    private String SHARE_LINK_BASE_URL = "https://www.hyundaiseltos.site/share.html";
 
 
     /**
@@ -113,7 +114,7 @@ public class EventLotsService {
         // 공유 링크 생성
         String uniqueLink;
         try {
-             uniqueLink = createUniqueLink(savedUser.getId());
+             uniqueLink = createUniqueLink(savedUser.getId(), savedUser.getTestResult().getId());
         } catch (Exception e) {
             throw new AESExecutionException("userId {"+savedUser.getId()+"} 암호화 과정 중 오류가 발생했습니다.");
         }
@@ -176,7 +177,7 @@ public class EventLotsService {
         findUserShareLink.increaseCount();
 
         // 해당 유저의 유형 링크 반환
-        return findUser.getTestResult().getUrl();
+        return uniqueLink;
     }
 
     @Transactional
@@ -186,7 +187,7 @@ public class EventLotsService {
     }
 
     //TODO("프론트 공유페이지 링크 나오면 수정")
-    private String createUniqueLink(Long userId) throws Exception {
-        return SERVER_HOST + "/lots/link/" + UrlUtils.encode(aesUtils.encrypt(String.valueOf(userId)));
+    private String createUniqueLink(Long userId, Long resultId) throws Exception {
+        return SHARE_LINK_BASE_URL+ "?id=" + resultId + "&UID=" + UrlUtils.encode(aesUtils.encrypt(String.valueOf(userId)));
     }
 }

--- a/src/main/java/com/softeer/podo/event/service/EventLotsService.java
+++ b/src/main/java/com/softeer/podo/event/service/EventLotsService.java
@@ -187,6 +187,6 @@ public class EventLotsService {
 
     //TODO("프론트 공유페이지 링크 나오면 수정")
     private String createUniqueLink(Long userId) throws Exception {
-        return SERVER_HOST + ":" + SERVER_PORT + "/lots/link/" + UrlUtils.encode(aesUtils.encrypt(String.valueOf(userId)));
+        return SERVER_HOST + "/lots/link/" + UrlUtils.encode(aesUtils.encrypt(String.valueOf(userId)));
     }
 }

--- a/src/main/java/com/softeer/podo/event/service/EventLotsService.java
+++ b/src/main/java/com/softeer/podo/event/service/EventLotsService.java
@@ -160,9 +160,9 @@ public class EventLotsService {
 
 
     /**
-     * 사용자의 고유 링크를 받고 복호화한 후 유형 링크 반환
+     * 사용자의 고유값을 받고 복호화한 후 공유 링크의 count를 올린 뒤 고유값 다시 반환
      * @param uniqueLink 사용자의 고유 링크
-     * @return 유형 페이지 url
+     * @return 고유값
      */
     @Transactional
     public String getEventUrl(String uniqueLink) throws Exception {
@@ -180,13 +180,23 @@ public class EventLotsService {
         return uniqueLink;
     }
 
+    /**
+     * 워드 클라우드용 단어 리스트를 뽑아내는 api
+     * @return 단어명 및 comment에 등장한 누계 횟수를 담은 dto
+     */
     @Transactional
     public WordCloudResponseDto getWordCloud() {
         List<KeyWord> keyWordList = keyWordRepository.findAll();
         return lotsEventMapper.KeyWordListToWordCloudResponseDto(keyWordList);
     }
 
-    //TODO("프론트 공유페이지 링크 나오면 수정")
+    /**
+     * uid와 result id 기반으로 FE의 공유 결과 페이지의 url을 생성
+     * @param userId 사용자 id
+     * @param resultId 유형테스트 결과 id
+     * @return 해당 사용자의 공유 링크
+     * @throws Exception aesUtils에서 나오는 exception
+     */
     private String createUniqueLink(Long userId, Long resultId) throws Exception {
         return SHARE_LINK_BASE_URL+ "?id=" + resultId + "&UID=" + UrlUtils.encode(aesUtils.encrypt(String.valueOf(userId)));
     }


### PR DESCRIPTION
## 🎯 이슈 번호
[Fix] 공유 링크에서 redirection 링크의 og tag가 안받아지는 오류 수정 #66
## 💡 작업 내용

- [x] 공유 링크 생성시 FE의 공유페이지에 직접 연결하도록 변경
- [x] 공유링크 redirection api를 공유링크 count 올리는 api로 수정

## 💡 자세한 설명
공유 링크 생성시 FE의 공유페이지에 직접 연결하면서 암호화된 uid를 path parameter로 넘기도록 수정
FE에서 호출할 수 있는 공유링크 조회 횟수 올리는 용도의 api 추가

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
